### PR TITLE
Update INSTALL-linux.md

### DIFF
--- a/INSTALL-linux.md
+++ b/INSTALL-linux.md
@@ -53,7 +53,9 @@ unit="circleci-$CIRCLECI_LAUNCH_ID"
 
 # When this process exits, tell the systemd unit to shut down
 abort() {
-  systemctl stop "$unit"
+  if systemctl is-active --quiet "$unit"; then
+    systemctl stop "$unit"
+  fi
 }
 trap abort EXIT
 


### PR DESCRIPTION
This keeps the script from exiting
with an error if build-agent has already exited by itself after
finishing the task.